### PR TITLE
Tjfe 111 feature 마이페이지 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ["lh3.googleusercontent.com"],
+    domains: [
+      "lh3.googleusercontent.com",
+      "travel-journal-s3.s3.amazonaws.com",
+    ],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-oauth/google": "^0.12.1",
         "@tanstack/react-query": "^5.67.1",
+        "axios": "^1.8.4",
         "next": "^15.2.4",
         "next-auth": "^4.24.11",
         "react": "^18.3.1",
@@ -1825,6 +1826,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1849,6 +1856,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1939,7 +1957,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2110,6 +2127,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -2295,6 +2324,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2336,7 +2374,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2431,7 +2468,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2441,7 +2477,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2479,7 +2514,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2492,7 +2526,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3099,6 +3132,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3132,6 +3185,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3151,7 +3219,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3192,7 +3259,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3217,7 +3283,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3352,7 +3417,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3424,7 +3488,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3437,7 +3500,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3453,7 +3515,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4183,7 +4244,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4211,6 +4271,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4963,6 +5044,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@react-oauth/google": "^0.12.1",
     "@tanstack/react-query": "^5.67.1",
+    "axios": "^1.8.4",
     "next": "^15.2.4",
     "next-auth": "^4.24.11",
     "react": "^18.3.1",

--- a/src/app/mypage/components/mypageMenu.tsx
+++ b/src/app/mypage/components/mypageMenu.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+const menuItems = [
+  { label: "프로필 수정", href: "/mypage/edit-profile" },
+  { label: "돌아오고 싶은 여행 일지", href: "/mypage/favorite-journals" },
+  { label: "저장한 여행 일지", href: "/mypage/saved-journals" },
+  { label: "계정 정보 관리", href: "/mypage/account" },
+  { label: "사용자 설정", href: "/mypage/settings" },
+];
+
+export default function MyPageMenu() {
+  return (
+    <ul className="divide-y divide-gray-200">
+      {menuItems.map((item) => (
+        <li key={item.href}>
+          <Link
+            href={item.href}
+            className="block px-4 py-4 text-sm font-medium text-gray-800 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
+          >
+            {item.label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/mypage/edit-profile/hooks/useProfileEdit.ts
+++ b/src/app/mypage/edit-profile/hooks/useProfileEdit.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { checkNickname } from "@/services/checknickname";
+import { updateProfile } from "@/services/updateProfile";
+import { useAuthStore } from "@/store/useAuthStore";
+
+export function useProfileEdit() {
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const [isNicknameValid, setIsNicknameValid] = useState<boolean | null>(null);
+
+  const checkNicknameMutation = useMutation({
+    mutationFn: async (nickname: string) => {
+      if (!accessToken) throw new Error("accessToken 없음");
+      const result = await checkNickname(nickname, accessToken);
+      setIsNicknameValid(result.success);
+      return result;
+    },
+    onError: () => setIsNicknameValid(false),
+  });
+
+  const updateProfileMutation = useMutation({
+    mutationFn: updateProfile,
+  });
+
+  return {
+    checkNicknameMutation,
+    updateProfileMutation,
+    isNicknameValid,
+    setIsNicknameValid,
+  };
+}

--- a/src/app/mypage/edit-profile/page.tsx
+++ b/src/app/mypage/edit-profile/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useProfileEdit } from "./hooks/useProfileEdit";
+import { useAuthStore } from "@/store/useAuthStore";
+
+export default function ProfileEdit() {
+  const router = useRouter();
+
+  const [nickname, setNickname] = useState("");
+  const [profileVisibility, setProfileVisibility] = useState("public");
+  const [profileImage, setProfileImage] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const {
+    checkNicknameMutation,
+    updateProfileMutation,
+    isNicknameValid,
+    setIsNicknameValid,
+  } = useProfileEdit();
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+    setIsNicknameValid(null);
+  };
+
+  const checkNicknameAvailability = async () => {
+    if (!nickname.trim()) return;
+    try {
+      const data = await checkNicknameMutation.mutateAsync(nickname);
+      setIsNicknameValid(data.success);
+    } catch (error) {
+      console.error("❌ 닉네임 중복 확인 오류:", error);
+      setIsNicknameValid(false);
+    }
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setProfileImage(file);
+      setPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const handleProfileSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isNicknameValid || nickname.trim() === "") return;
+
+    const accessToken = useAuthStore.getState().accessToken; // ✅ 추가
+
+    if (!accessToken) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
+
+    updateProfileMutation.mutate(
+      {
+        nickname,
+        profileVisibility,
+        profileImage,
+        accessToken, // ✅ 명시적으로 전달
+      },
+      {
+        onSuccess: () => {
+          alert("✅ 프로필이 저장되었습니다!");
+          router.push("/mypage");
+        },
+        onError: (err) => {
+          console.error("❌ 프로필 저장 실패:", err);
+          alert("프로필 저장에 실패했습니다. 다시 시도해주세요.");
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="flex justify-center items-center w-full">
+      <form
+        onSubmit={handleProfileSubmit}
+        className="w-full p-8 rounded-lg flex flex-col items-center gap-6"
+      >
+        <h2 className="text-2xl font-semibold">프로필 수정</h2>
+
+        <label className="relative cursor-pointer">
+          <div className="w-24 h-24 rounded-full border overflow-hidden flex items-center justify-center bg-gray-200">
+            {preview ? (
+              <Image
+                src={preview}
+                alt="Profile Preview"
+                className="w-full h-full object-cover"
+                width={96}
+                height={96}
+              />
+            ) : (
+              <span className="text-gray-500 absolute bottom-0 right-0">
+                📷
+              </span>
+            )}
+          </div>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleImageChange}
+            className="hidden"
+          />
+        </label>
+
+        <div className="w-full">
+          <label className="block text-gray-600">닉네임</label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={nickname}
+              onChange={handleNicknameChange}
+              className="border p-2 w-full rounded"
+            />
+            <button
+              type="button"
+              onClick={checkNicknameAvailability}
+              className={`px-3 py-2 rounded min-w-32 ${
+                checkNicknameMutation.isPending
+                  ? "bg-gray-400"
+                  : "bg-gray-300 hover:bg-gray-400"
+              }`}
+              disabled={checkNicknameMutation.isPending}
+            >
+              {checkNicknameMutation.isPending ? "확인 중..." : "중복 확인"}
+            </button>
+          </div>
+          {isNicknameValid === false && (
+            <p className="text-red-500 text-sm mt-1">
+              이미 사용 중인 아이디입니다.
+            </p>
+          )}
+          {isNicknameValid === true && (
+            <p className="text-green-500 text-sm mt-1">
+              사용 가능한 닉네임입니다.
+            </p>
+          )}
+        </div>
+
+        <div className="w-full">
+          <label className="block text-gray-600">프로필 공개 범위</label>
+          <select
+            value={profileVisibility}
+            onChange={(e) => setProfileVisibility(e.target.value)}
+            className="border p-2 w-full rounded outline-none"
+          >
+            <option value="public">전체 공개</option>
+            <option value="friends">친구 공개</option>
+            <option value="private">비공개</option>
+          </select>
+        </div>
+        <button
+          type="submit"
+          className={`w-full py-2 text-white rounded ${
+            updateProfileMutation.isPending
+              ? "bg-gray-400 cursor-not-allowed"
+              : "bg-blue-500 hover:bg-blue-600"
+          }`}
+          disabled={updateProfileMutation.isPending}
+        >
+          {updateProfileMutation.isPending ? "저장 중..." : "작성 완료"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,3 +1,53 @@
+"use client";
+
+import Image from "next/image";
+import { useMemberInfo } from "../features/member/hooks/useMemberInfo";
+import MyPageMenu from "./components/mypageMenu";
+
 export default function MyPage() {
-  return <h1>마이페이지</h1>;
+  const { data: member, isLoading } = useMemberInfo();
+
+  if (isLoading || !member) return <div>로딩 중...</div>;
+
+  const profile = member.profileInfo;
+  return (
+    <>
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* 닉네임 + 프로필 */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Image
+              src={profile.profileImageUrl || "/default-avatar.png"}
+              alt="프로필 이미지"
+              width={72}
+              height={72}
+              className="rounded-full object-cover"
+            />
+            <div className="text-xl font-semibold">{profile.nickname}</div>
+          </div>
+        </div>
+
+        {/* 통계 */}
+        <div className="flex justify-around mt-6 text-center">
+          <div>
+            <div className="text-lg font-bold">{profile.followerCount}</div>
+            <div className="text-sm text-gray-500">팔로워</div>
+          </div>
+          <div>
+            <div className="text-lg font-bold">{profile.followingCount}</div>
+            <div className="text-sm text-gray-500">팔로잉</div>
+          </div>
+          <div>
+            <div className="text-lg font-bold">{profile.travelDiaryCount}</div>
+            <div className="text-sm text-gray-500">여행일지</div>
+          </div>
+          <div>
+            <div className="text-lg font-bold">{profile.placesCount}</div>
+            <div className="text-sm text-gray-500">플레이스</div>
+          </div>
+        </div>
+      </div>
+      <MyPageMenu></MyPageMenu>
+    </>
+  );
 }

--- a/src/services/updateProfile.ts
+++ b/src/services/updateProfile.ts
@@ -1,0 +1,43 @@
+// services/updateProfile.ts
+
+import { apiEndpoint } from "@/app/shared/constants";
+
+interface UpdateProfilePayload {
+  nickname: string;
+  profileVisibility: string;
+  profileImage?: File | null;
+  accessToken: string;
+}
+
+export async function updateProfile(payload: UpdateProfilePayload) {
+  const formData = new FormData();
+
+  const jsonBody = JSON.stringify({
+    nickname: payload.nickname,
+    accountScope: payload.profileVisibility.toUpperCase(),
+  });
+
+  formData.append(
+    "profileRequest",
+    new Blob([jsonBody], { type: "application/json" })
+  );
+
+  if (payload.profileImage) {
+    formData.append("profileImage", payload.profileImage);
+  }
+
+  const res = await fetch(`${apiEndpoint}/v1/member/profile/update`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${payload.accessToken}`,
+    },
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(`프로필 수정 실패: ${error}`);
+  }
+
+  return res;
+}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-interface User {
+export interface User {
   memberId: number;
   email?: string;
   name?: string;
@@ -32,26 +32,19 @@ export const useAuthStore = create<AuthState>()(
         console.log("✅ Access Token 저장:", token);
         set({ accessToken: token });
       },
-      resetAuth: () =>
-        set({
-          accessToken: null,
-          user: null,
-        }),
+      resetAuth: () => set({ accessToken: null, user: null }),
     }),
     {
       name: "auth-storage",
       storage: {
         getItem: (name) => {
           const item = sessionStorage.getItem(name);
-          console.log(`🔍 세션 스토리지에서 ${name} 가져옴:`, item);
           return item ? JSON.parse(item) : null;
         },
         setItem: (name, value) => {
-          console.log(`💾 세션 스토리지에 ${name} 저장:`, value);
           sessionStorage.setItem(name, JSON.stringify(value));
         },
         removeItem: (name) => {
-          console.log(`🗑️ 세션 스토리지에서 ${name} 삭제`);
           sessionStorage.removeItem(name);
         },
       },

--- a/src/utils/fetchWithAuth.ts
+++ b/src/utils/fetchWithAuth.ts
@@ -1,0 +1,54 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import { useAuthStore } from "@/store/useAuthStore";
+import { apiEndpoint } from "@/app/shared/constants";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function fetchWithAuth<T = any>(
+  url: string,
+  config: AxiosRequestConfig = {}
+): Promise<AxiosResponse<T>> {
+  const { accessToken, user, setAccessToken, setUser, resetAuth } =
+    useAuthStore.getState();
+
+  const makeRequest = async (token: string) => {
+    return axios({
+      ...config,
+      url: `${apiEndpoint}${url}`,
+      headers: {
+        ...(config.headers || {}),
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  };
+
+  try {
+    return await makeRequest(accessToken!);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    if (
+      error.response?.status === 401 &&
+      user?.refreshToken &&
+      user?.deviceId
+    ) {
+      try {
+        const res = await axios.post(`${apiEndpoint}/v1/tokens/reissue`, {
+          refreshToken: user.refreshToken,
+          deviceId: user.deviceId,
+        });
+
+        const { accessToken: newToken, user: newUser } = res.data;
+
+        setAccessToken(newToken);
+        setUser(newUser);
+
+        return await makeRequest(newToken);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (refreshError) {
+        resetAuth();
+        throw new Error("세션이 만료되었습니다. 다시 로그인해주세요.");
+      }
+    }
+
+    throw error;
+  }
+}


### PR DESCRIPTION
### 주요 변경 사항

- `/mypage/edit-profile` 페이지 생성 및 프로필 수정 UI 구현
- 프로필 이미지 변경, 닉네임 수정, 공개 범위 설정 가능
- `useProfileEdit` 커스텀 훅 구현
  - 닉네임 중복 확인 (`GET /v1/member/check-nickname/:nickname`)
  - 프로필 수정 요청 (`PUT /v1/member/profile/update`)
- `updateProfile` 서비스 함수 생성 (multipart/form-data 전송)
- `fetchWithAuth` 유틸 생성
  - `Authorization` 헤더 자동 주입
  - `401` 발생 시 `refreshToken` 기반 accessToken 재발급 및 원 요청 재시도
- `useAuthStore`에 저장된 `refreshToken`, `deviceId` 활용하여 토큰 재발급 흐름 구성

---

### 앞으로 진행할 예정 작업

- [ ] 프로필 수정 후 `useAuthStore`의 nickname, profileImage 등 상태 갱신
- [ ] 프로필 이미지 없는 경우 기본 이미지 처리 (preview 초기값)
- [ ] 기존 값과 변경값 비교하여 불필요한 요청 방지

---

### 기타

- 기존 `saveProfile` (온보딩용) API는 유지하고, 수정은 `updateProfile`로 분리 관리함
- `checkNickname`은 공통 유틸로 유지하며 두 로직에서 재사용 중

