### PR TITLE
feat(search): 검색 페이지 및 사용자 검색 기능 구현

### DIFF
--- a/src/app/(main)/search/page.tsx
+++ b/src/app/(main)/search/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+import SearchTabs from "@/features/search/components/searchTabs";
+import SearchInput from "@/features/search/components/searchInput";
+import MemberSearchResult from "@/features/search/components/MemberSearchResult";
+
+type TabValue = "member" | "diary" | "place";
+
+export default function SearchPage() {
+  const [keyword, setKeyword] = useState("");
+  const [tab, setTab] = useState<"member" | "diary" | "place">("member");
+
+  return (
+    <div className="max-w-screen-lg mx-auto px-4 pt-8">
+      <h1 className="text-xl font-semibold mb-6">검색</h1>
+      <SearchInput value={keyword} onChange={setKeyword} />
+      <SearchTabs
+        currentTab={tab}
+        onTabChange={(value) => setTab(value as TabValue)}
+      />
+      <div className="mt-4">
+        {tab === "member" && <MemberSearchResult keyword={keyword} />}
+        {tab === "diary" && <MemberSearchResult keyword={keyword} />}
+        {tab === "place" && <MemberSearchResult keyword={keyword} />}
+      </div>
+    </div>
+  );
+}

--- a/src/features/search/components/MemberSearchResult.tsx
+++ b/src/features/search/components/MemberSearchResult.tsx
@@ -1,0 +1,35 @@
+import Image from "next/image";
+import { useMemberSearch } from "../hooks/useSearchMember";
+
+interface Props {
+  keyword: string;
+}
+
+export default function MemberSearchResult({ keyword }: Props) {
+  const { data, isLoading } = useMemberSearch({ keyword });
+
+  if (!keyword)
+    return <p className="text-sm text-gray-400">검색어를 입력해주세요</p>;
+  if (isLoading) return <p>검색 중...</p>;
+
+  return (
+    <ul className="space-y-4 mt-2">
+      {data?.content.map((member) => (
+        <li key={member.memberId} className="flex items-center gap-3">
+          <Image
+            src={member.profileImageUrl}
+            alt="profile"
+            className="w-10 h-10 rounded-full object-cover"
+            width={16}
+            height={16}
+          />
+          <div>
+            <p className="font-medium">{member.nickname}</p>
+            <p className="text-xs text-gray-500">✈️ 23 📍 77</p>{" "}
+            {/* dummy로 표시 */}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/search/components/searchInput.tsx
+++ b/src/features/search/components/searchInput.tsx
@@ -1,0 +1,24 @@
+import { Search } from "lucide-react";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function SearchInput({ value, onChange }: Props) {
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        placeholder="장소, 사람 검색하기"
+        className="w-full px-4 py-2 pr-10 border rounded-md text-sm shadow-sm"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <Search
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400"
+        size={16}
+      />
+    </div>
+  );
+}

--- a/src/features/search/components/searchTabs.tsx
+++ b/src/features/search/components/searchTabs.tsx
@@ -1,0 +1,36 @@
+export type TabValue = "member" | "diary" | "place";
+
+interface SearchTabsProps {
+  currentTab: TabValue;
+  onTabChange: (value: TabValue) => void;
+}
+
+const tabs: { key: TabValue; label: string }[] = [
+  { key: "member", label: "여행자" },
+  { key: "diary", label: "여행 일지" },
+  { key: "place", label: "플레이스" },
+];
+
+export default function SearchTabs({
+  currentTab,
+  onTabChange,
+}: SearchTabsProps) {
+  return (
+    <div className="flex border-b border-gray-200 mt-4">
+      {tabs.map((tab) => (
+        <button
+          key={tab.key}
+          onClick={() => onTabChange(tab.key)}
+          className={`px-4 py-2 text-sm font-medium transition-all
+            ${
+              currentTab === tab.key
+                ? "text-black border-b-2 border-purple-500"
+                : "text-gray-400 hover:text-black"
+            }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/search/hooks/useSearchMember.ts
+++ b/src/features/search/hooks/useSearchMember.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import axiosInstance from "@/lib/axiosInstance";
+
+interface MemberSearchParams {
+  keyword: string;
+  page?: number;
+  size?: number;
+}
+
+interface MemberSearchResult {
+  content: Array<{
+    memberId: number;
+    nickname: string;
+    profileImageUrl: string;
+  }>;
+  totalPages: number;
+  totalElements: number;
+  number: number;
+  size: number;
+}
+
+export const useMemberSearch = ({
+  keyword,
+  page = 0,
+  size = 10,
+}: MemberSearchParams) => {
+  return useQuery({
+    queryKey: ["searchMembers", keyword, page, size],
+    queryFn: async () => {
+      const res = await axiosInstance.get<MemberSearchResult>(
+        "/v1/search/members",
+        {
+          params: {
+            keyword,
+            page,
+            size,
+          },
+        }
+      );
+      return res.data;
+    },
+    enabled: !!keyword, // 키워드가 있어야만 요청
+    staleTime: 1000 * 30, // 30초 캐시
+  });
+};


### PR DESCRIPTION
- /search 경로에 검색 페이지 추가
- 여행자/일지/플레이스 탭 UI 구성 (Tailwind 커스텀 탭 사용)
- 사용자 검색 input 및 결과 리스트 컴포넌트 작성
- useSearchMember 훅 구현 (TanStack Query + axiosInstance)