### PR TITLE
feat: 여행일지 작성 페이지 및 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
         "@react-oauth/google": "^0.12.1",
         "@tanstack/react-query": "^5.67.1",
         "axios": "^1.8.4",
+        "exif-js": "^2.3.0",
         "framer-motion": "^12.6.3",
         "lucide-react": "^0.487.0",
         "next": "^15.2.4",
         "next-auth": "^4.24.11",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-kakao-maps-sdk": "^1.1.27",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -27,6 +29,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.1.7",
+        "kakao.maps.d.ts": "^0.1.40",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.8.2"
@@ -5427,6 +5430,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exif-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/exif-js/-/exif-js-2.3.0.tgz",
+      "integrity": "sha512-1Og9pAzG2FZRVlaavH8bB8BTeHcjMdJhKmeQITkX+uLRCD0xPtKAdZ2clZmQdJ56p9adXtJ8+jwrGp/4505lYg==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6606,6 +6615,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7698,6 +7713,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.27.tgz",
+      "integrity": "sha512-1EwYkYsjTDRFqysKStDasFMrFTXcLx2AyRlqMoWD7ONWhRqpjx9M874hkhEEHrnypP2eSIhhDLe0EiSKp3bd2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "@react-oauth/google": "^0.12.1",
     "@tanstack/react-query": "^5.67.1",
     "axios": "^1.8.4",
+    "exif-js": "^2.3.0",
     "framer-motion": "^12.6.3",
     "lucide-react": "^0.487.0",
     "next": "^15.2.4",
     "next-auth": "^4.24.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-kakao-maps-sdk": "^1.1.27",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
@@ -28,6 +30,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.1.7",
+    "kakao.maps.d.ts": "^0.1.40",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.8.2"

--- a/src/app/(main)/journal/write/page.tsx
+++ b/src/app/(main)/journal/write/page.tsx
@@ -1,19 +1,47 @@
 "use client";
 
-import { useState } from "react";
-import Image from "next/image";
-import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
 import { TopBar } from "@/features/common/TopBar";
+import { extractLatLng } from "@/lib/extractLatLng";
+import { getLocationName } from "@/services/geoLoactionName";
+
+import ImageUploader from "@/features/jorunal/components/ImageUploader";
+import LocationMapSection from "@/features/jorunal/components/LoactionSection";
 
 export default function WriteJournalPage() {
-  const [images, setImages] = useState<File[]>([]);
+  const [imagesWithMeta, setImagesWithMeta] = useState<
+    { file: File; lat?: number; lng?: number; keyword?: string }[]
+  >([]);
+  const [locationNames, setLocationNames] = useState<string[]>([]);
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  useEffect(() => {
+    imagesWithMeta.forEach((img, idx) => {
+      if (img.lat && img.lng) {
+        getLocationName(img.lat, img.lng, (name) => {
+          setLocationNames((prev) => {
+            const newNames = [...prev];
+            newNames[idx] = name;
+            return newNames;
+          });
+        });
+      }
+    });
+  }, [imagesWithMeta]);
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files) return;
 
-    const fileArray = Array.from(files).slice(0, 10 - images.length);
-    setImages((prev) => [...prev, ...fileArray]);
+    const fileArray = Array.from(files).slice(0, 10 - imagesWithMeta.length);
+
+    const updatedImages = await Promise.all(
+      fileArray.map(async (file) => {
+        const { lat, lng } = await extractLatLng(file);
+        return { file, lat, lng };
+      })
+    );
+
+    setImagesWithMeta((prev) => [...prev, ...updatedImages]);
   };
 
   return (
@@ -21,49 +49,12 @@ export default function WriteJournalPage() {
       <TopBar title="여행 일지 작성하기" center />
 
       <form className="space-y-6">
-        {/* 이미지 업로더 */}
-        <div>
-          <label className="block mb-2 text-sm font-medium text-gray-700">
-            여행 사진 추가
-          </label>
-          <div className="grid grid-cols-5 gap-2">
-            {images.length < 10 && (
-              <label
-                htmlFor="image-upload"
-                className="aspect-square flex items-center justify-center border border-dashed border-gray-300 rounded-lg bg-gray-100 cursor-pointer hover:bg-gray-200"
-              >
-                <Plus className="w-6 h-6 text-gray-500" />
-                <input
-                  id="image-upload"
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  onChange={handleImageChange}
-                  className="hidden"
-                />
-              </label>
-            )}
+        <ImageUploader
+          imagesWithMeta={imagesWithMeta}
+          setImagesWithMeta={setImagesWithMeta}
+          handleImageChange={handleImageChange}
+        />
 
-            {images.map((file, index) => (
-              <div
-                key={index}
-                className="relative aspect-square rounded-lg overflow-hidden"
-              >
-                <Image
-                  src={URL.createObjectURL(file)}
-                  alt={`uploaded-${index}`}
-                  fill
-                  className="object-cover"
-                />
-              </div>
-            ))}
-          </div>
-          <span className="block mt-2 text-sm text-gray-600">
-            {images.length}장 / 10장
-          </span>
-        </div>
-
-        {/* 장소 & 날짜 */}
         <div className="flex items-center gap-2">
           <p className="text-sm text-gray-500 font-medium">장소</p>
           <input
@@ -81,7 +72,6 @@ export default function WriteJournalPage() {
           />
         </div>
 
-        {/* 제목/컨셉/내용 */}
         <div className="space-y-4">
           <input
             type="text"
@@ -100,23 +90,10 @@ export default function WriteJournalPage() {
           />
         </div>
 
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3">
-          <h3 className="text-sm font-semibold">1일차</h3>
-          <p className="text-sm text-gray-500">
-            1일차에 관련된 설명을 추가할 수 있습니다.
-          </p>
-
-          <div className="w-full h-48 bg-gray-200 rounded-md flex items-center justify-center text-gray-500 text-sm">
-            (지도 컴포넌트 들어갈)
-          </div>
-
-          <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1">
-            <li>A. 하도해수욕장</li>
-            <li>B. 김녕해변</li>
-            <li>C. 제주 나도돌 테마파크</li>
-            <li>D. 제주 워터돔</li>
-          </ul>
-        </div>
+        <LocationMapSection
+          imagesWithMeta={imagesWithMeta}
+          locationNames={locationNames}
+        />
       </form>
     </div>
   );

--- a/src/features/jorunal/components/ImageUploader.tsx
+++ b/src/features/jorunal/components/ImageUploader.tsx
@@ -1,59 +1,90 @@
-"use client";
-
-import { useState } from "react";
+// components/ImageUploader.tsx
 import Image from "next/image";
 import { Plus } from "lucide-react";
+import { searchPlace } from "@/services/SearchPlace";
 
-export default function ImageUploader() {
-  const [images, setImages] = useState<File[]>([]);
+interface Props {
+  imagesWithMeta: {
+    file: File;
+    lat?: number;
+    lng?: number;
+    keyword?: string;
+  }[];
+  setImagesWithMeta: React.Dispatch<
+    React.SetStateAction<
+      { file: File; lat?: number; lng?: number; keyword?: string }[]
+    >
+  >;
+  handleImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files) return;
-
-    const fileArray = Array.from(files).slice(0, 10 - images.length);
-    setImages((prev) => [...prev, ...fileArray]);
-  };
-
+export default function ImageUploader({
+  imagesWithMeta,
+  setImagesWithMeta,
+  handleImageChange,
+}: Props) {
   return (
-    <div className="w-full">
-      {/* 이미지 업로드 영역 */}
+    <div>
+      <label className="block mb-2 text-sm font-medium text-gray-700">
+        여행 사진 추가
+      </label>
       <div className="grid grid-cols-5 gap-2">
-        {/* + 버튼 */}
-        <label
-          htmlFor="image-upload"
-          className="aspect-square flex items-center justify-center border border-dashed border-gray-300 rounded-lg bg-gray-100 cursor-pointer hover:bg-gray-200"
-        >
-          <Plus className="w-6 h-6 text-gray-500" />
-          <input
-            id="image-upload"
-            type="file"
-            accept="image/*"
-            multiple
-            onChange={handleChange}
-            className="hidden"
-          />
-        </label>
+        {imagesWithMeta.length < 10 && (
+          <label
+            htmlFor="image-upload"
+            className="aspect-square flex items-center justify-center border border-dashed border-gray-300 rounded-lg bg-gray-100 cursor-pointer hover:bg-gray-200"
+          >
+            <Plus className="w-6 h-6 text-gray-500" />
+            <input
+              id="image-upload"
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleImageChange}
+              className="hidden"
+            />
+          </label>
+        )}
 
-        {/* 업로드된 이미지 */}
-        {images.map((file, index) => (
+        {imagesWithMeta.map((img, index) => (
           <div
             key={index}
-            className="relative aspect-square rounded-lg overflow-hidden"
+            className="relative aspect-square rounded-lg overflow-hidden border border-gray-300"
           >
             <Image
-              src={URL.createObjectURL(file)}
+              src={URL.createObjectURL(img.file)}
               alt={`uploaded-${index}`}
               fill
               className="object-cover"
             />
+            {!img.lat && (
+              <input
+                type="text"
+                placeholder="위치 키워드 입력"
+                className="absolute bottom-1 left-1 w-[calc(100%-0.5rem)] bg-white/70 text-xs rounded p-1"
+                onBlur={(e) => {
+                  const keyword = e.target.value;
+                  searchPlace(keyword, (lat, lng) => {
+                    setImagesWithMeta((prev) =>
+                      prev.map((image, i) =>
+                        i === index ? { ...image, lat, lng, keyword } : image
+                      )
+                    );
+                  });
+                }}
+              />
+            )}
+            {img.lat && img.lng && (
+              <div className="absolute bottom-1 left-1 bg-white/70 text-xs rounded p-1">
+                <p>위도: {img.lat.toFixed(5)}</p>
+                <p>경도: {img.lng.toFixed(5)}</p>
+              </div>
+            )}
           </div>
         ))}
       </div>
-
-      {/* 업로드 수 카운트 */}
       <span className="block mt-2 text-sm text-gray-600">
-        {images.length}장 / 10장
+        {imagesWithMeta.length}장 / 10장
       </span>
     </div>
   );

--- a/src/features/jorunal/components/LoactionSection.tsx
+++ b/src/features/jorunal/components/LoactionSection.tsx
@@ -1,0 +1,52 @@
+import Script from "next/script";
+import KakaoMapstest from "@/features/test/kakaoMapstest";
+
+interface Props {
+  imagesWithMeta: {
+    file: File;
+    lat?: number;
+    lng?: number;
+    keyword?: string;
+  }[];
+  locationNames: string[];
+}
+
+export const API = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JS_KEY}&libraries=services,clusterer&autoload=false`;
+
+export default function LocationMapSection({
+  imagesWithMeta,
+  locationNames,
+}: Props) {
+  return (
+    <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-3">
+      <h3 className="text-sm font-semibold">1일차</h3>
+      <input
+        type="text"
+        placeholder="1일차의 내용을 적어주세요"
+        className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+      />
+
+      <div className="w-full h-48 bg-gray-200 rounded-md flex items-center justify-center text-gray-500 text-sm overflow-hidden">
+        <Script src={API} strategy="afterInteractive" />
+        <KakaoMapstest
+          places={imagesWithMeta
+            .filter((img) => img.lat && img.lng)
+            .map((img, index) => ({
+              id: index.toString(),
+              lat: img.lat!,
+              lng: img.lng!,
+              name: img.keyword ?? `장소 ${index + 1}`,
+            }))}
+        />
+      </div>
+
+      <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1">
+        {locationNames.map((name, idx) => (
+          <li key={idx}>
+            {String.fromCharCode(65 + idx)}. {name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/test/kakaoMapstest.tsx
+++ b/src/features/test/kakaoMapstest.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Map, CustomOverlayMap, Polyline } from "react-kakao-maps-sdk";
+
+interface Place {
+  id: string;
+  lat: number;
+  lng: number;
+  name: string;
+}
+
+export default function KakaoMapstest({ places }: { places: Place[] }) {
+  // 지도 중심: 첫 번째 마커 위치, 없으면 서울
+  const center = places.length
+    ? { lat: places[0].lat, lng: places[0].lng }
+    : { lat: 37.5665, lng: 126.978 };
+
+  return (
+    <Map center={center} style={{ width: "100%", height: "100%" }} level={5}>
+      {/* 마커들 */}
+      {places.map((place, idx) => (
+        <CustomOverlayMap
+          key={place.id}
+          position={{ lat: place.lat, lng: place.lng }}
+        >
+          <div
+            style={{
+              backgroundColor: "#A55FF5", // 보라색
+              color: "white",
+              width: "30px",
+              height: "30px",
+              borderRadius: "50%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "14px",
+              fontWeight: "bold",
+            }}
+          >
+            {String.fromCharCode(65 + idx)} {/* A, B, C... */}
+          </div>
+        </CustomOverlayMap>
+      ))}
+
+      {places.length > 1 && (
+        <Polyline
+          path={places.map((p) => ({
+            lat: p.lat,
+            lng: p.lng,
+          }))}
+          strokeWeight={2}
+          strokeColor="#A55FF5"
+          strokeOpacity={0.7}
+          strokeStyle="solid"
+        />
+      )}
+    </Map>
+  );
+}

--- a/src/features/test/useKakaoLoader.tsx
+++ b/src/features/test/useKakaoLoader.tsx
@@ -1,0 +1,9 @@
+import { useKakaoLoader as useKakaoLoaderOrigin } from "react-kakao-maps-sdk";
+
+export default function useKakaoLoader() {
+  useKakaoLoaderOrigin({
+    appkey: process.env.NEXT_PUBLIC_KAKAO_JS_KEY ?? "",
+    // 타입 undefined → 빈 문자열로 대체
+    libraries: ["clusterer", "drawing", "services"],
+  });
+}

--- a/src/lib/extractLatLng.ts
+++ b/src/lib/extractLatLng.ts
@@ -1,0 +1,26 @@
+import EXIF from "exif-js";
+
+export function extractLatLng(
+  file: File
+): Promise<{ lat?: number; lng?: number }> {
+  return new Promise((resolve) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    EXIF.getData(file as any, function (this: any) {
+      const lat = EXIF.getTag(this, "GPSLatitude");
+      const lng = EXIF.getTag(this, "GPSLongitude");
+      const latRef = EXIF.getTag(this, "GPSLatitudeRef");
+      const lngRef = EXIF.getTag(this, "GPSLongitudeRef");
+
+      if (lat && lng) {
+        const latitude =
+          (lat[0] + lat[1] / 60 + lat[2] / 3600) * (latRef === "S" ? -1 : 1);
+        const longitude =
+          (lng[0] + lng[1] / 60 + lng[2] / 3600) * (lngRef === "W" ? -1 : 1);
+
+        resolve({ lat: latitude, lng: longitude });
+      } else {
+        resolve({});
+      }
+    });
+  });
+}

--- a/src/services/SearchPlace.ts
+++ b/src/services/SearchPlace.ts
@@ -1,0 +1,19 @@
+export function searchPlace(
+  keyword: string,
+  callback: (lat: number, lng: number) => void
+) {
+  if (!window.kakao) return;
+  const ps = new window.kakao.maps.services.Places();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ps.keywordSearch(keyword, (result: any[], status: string) => {
+    if (status === window.kakao.maps.services.Status.OK) {
+      const { y, x } = result[0];
+      const lat = parseFloat(y);
+      const lng = parseFloat(x);
+      callback(lat, lng);
+    } else {
+      console.log("검색 결과 없음");
+    }
+  });
+}

--- a/src/services/geoLoactionName.ts
+++ b/src/services/geoLoactionName.ts
@@ -1,0 +1,23 @@
+export function getLocationName(
+  lat: number,
+  lng: number,
+  callback: (address: string) => void
+) {
+  if (!window.kakao) return;
+
+  const geocoder = new window.kakao.maps.services.Geocoder();
+
+  const coord = new window.kakao.maps.LatLng(lat, lng);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const callbackFn = function (result: any, status: string) {
+    if (status === window.kakao.maps.services.Status.OK) {
+      const roadAddress = result[0].road_address?.address_name;
+      const address = result[0].address?.address_name;
+      callback(roadAddress || address || "위치명 없음");
+    } else {
+      callback("위치명 없음");
+    }
+  };
+
+  geocoder.coord2Address(coord.getLng(), coord.getLat(), callbackFn);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["kakao.maps.d.ts"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
- 여행 사진 업로드 기능 구현
  - 최대 10장까지 업로드 가능
  - 업로드한 이미지에 EXIF 데이터를 기반으로 위도/경도 정보 추출 (exif-js)
  - 위치 정보가 없을 경우, 사용자 키워드 검색으로 좌표 등록 가능

- 지도 및 위치 리스트 기능 구현
  - react-kakao-maps-sdk를 사용해 KakaoMapstest 컴포넌트에서 마커 & 경로 Polyline 렌더링
  - 업로드한 사진 위치 정보 기반으로 지도 마커 및 여행 경로 자동 생성
  - Kakao reverse geocoding API를 사용해 위치명 리스트 자동화
  - 위치명 검색 실패시 '위치명 없음' 표시

- 컴포넌트 분리 및 재사용성 향상
  - ImageUploader 컴포넌트: 이미지 업로드 & 위치 입력 UI 관리
  - LocationMapSection 컴포넌트: Kakao 지도 & 위치명 리스트 출력
  - useKakaoLoader 훅: Kakao Maps 스크립트 로드 관리
  - extractLatLng, geoLocationName, SearchPlace 서비스 함수로 기능 분리

- 패키지 설치
  - exif-js: EXIF 메타데이터 파싱
  - react-kakao-maps-sdk: Kakao Maps 연동

- UI/UX 개선
  - 지도/마커/위치명 리스트와 업로드된 이미지가 직관적으로 연결됨
  - 이미지 업로드 개수 표시 (2장 / 10장)
  - 업로드된 이미지마다 위도/경도 표시 (EXIF 기반)
  - 사진 선택 전에는 지도 영역이 비활성화 (추가 UX 고려)